### PR TITLE
get working on 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A Julia interface to the SQLite library and support for operations on DataFrames
 * `execute(stmt::SQLiteStmt)`
   `execute(db::SQLiteDB, sql::String)`
 
-  Used to execute prepared `SQLiteStmt`. The 2nd method is a convenience method to pass in an SQL statement as a string which gets prepared and executed in one call. This method does not check for or return any results, hence it is only useful for database manipulation methods (i.e. ALTER, CREATE, UPDATE, DROP). To return results, see `query` below. Also consider the `create`, `drop`, and `append` methods for manipulation statements as further SQLite performance tricks are incorporated automatically.
+  Used to execute prepared `SQLiteStmt`. The 2nd method is a convenience method to pass in an SQL statement as a string which gets prepared and executed in one call. This method does not check for or return any results, hence it is only useful for database manipulation methods (i.e. ALTER, CREATE, UPDATE, DROP). To return results, see `query` below. Also consider the `create`, `droptable`, and `append` methods for manipulation statements as further SQLite performance tricks are incorporated automatically.
 
 * `query(db::SQLiteDB, sql::String, values=[])`
 
@@ -73,9 +73,9 @@ A Julia interface to the SQLite library and support for operations on DataFrames
 
   Takes the values in `table` and appends (by repeated inserts) to the SQLite table `name`. No column checking is done to ensure correct types, so care should be taken as SQLite is "typeless" in that it allows items of any type to be stored in columns. Transaction handling is automatic as well as performance enhancements.
 
-* `drop(db::SQLiteDB,table::String)`
+* `droptable(db::SQLiteDB,table::String)`
 
-  `drop` is pretty self-explanatory. It's really just a convenience wrapper around `query` to execute a DROP TABLE command, while also calling "VACUUM" to clean out freed memory from the database.
+  `droptable` is pretty self-explanatory. It's really just a convenience wrapper around `query` to execute a DROP TABLE command, while also calling "VACUUM" to clean out freed memory from the database.
 
 * `register(db::SQLiteDB, func::Function; nargs::Int=-1, name::AbstractString=string(func), isdeterm::Bool=true)`
 * `register(db::SQLiteDB, init, step::Function, final::Function=identity; nargs::Int=-1, name::AbstractString=string(final), isdeterm::Bool=true)`

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.3-
 BinDeps
+Compat
 @osx Homebrew
 @windows WinRPM

--- a/src/show.jl
+++ b/src/show.jl
@@ -39,10 +39,10 @@ begin
         return position(io)
     end
     ourstrwidth(x::AbstractString) = strwidth(x) + 2 # -> Int
-    ourstrwidth(s::Symbol) = int(ccall(:u8_strwidth,
+    ourstrwidth(s::Symbol) = @compat Int(ccall(:u8_strwidth,
                                        Csize_t,
                                        (Ptr{Uint8}, ),
-                                       convert(Ptr{Uint8}, s)))
+                                       string(s)))
 end
 
 #' @description


### PR DESCRIPTION
Fixes all the compatibility issues necessary to get working on 0.4.

The only breaking change is the rename of `drop` to `droptable`, to avoid conflict with method in Base.