### PR TITLE
Fixes for julia 0.4

### DIFF
--- a/src/UDF.jl
+++ b/src/UDF.jl
@@ -16,8 +16,8 @@ function sqlvalue(values, i)
     elseif valuetype == SQLITE_BLOB
         nbytes = sqlite3_value_bytes(temp_val_ptr)
         blob = sqlite3_value_blob(temp_val_ptr)
-        buf = zeros(Uint8, nbytes)
-        unsafe_copy!(pointer(buf), convert(Ptr{Uint8}, blob), nbytes)
+        buf = zeros(UInt8, nbytes)
+        unsafe_copy!(pointer(buf), convert(Ptr{UInt8}, blob), nbytes)
         return sqldeserialize(buf)
     else
         return NULL
@@ -195,14 +195,14 @@ function register(db::SQLiteDB, func::Function; nargs::Int=-1, name::AbstractStr
 
     f = eval(scalarfunc(func,symbol(name)))
 
-    cfunc = cfunction(f, Nothing, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
+    cfunc = cfunction(f, Void, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
     # TODO: allow the other encodings
     enc = SQLITE_UTF8
     enc = isdeterm ? enc | SQLITE_DETERMINISTIC : enc
 
     @CHECK db sqlite3_create_function_v2(
         db.handle, name, nargs, enc, C_NULL, cfunc, C_NULL, C_NULL, C_NULL
-    )    
+    )
 end
 
 # as above but for aggregate functions
@@ -215,9 +215,9 @@ function register(
     @assert sizeof(name) <= 255 "size of function name must be <= 255 chars"
 
     s = eval(stepfunc(init, step, Base.function_name(step)))
-    cs = cfunction(s, Nothing, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
+    cs = cfunction(s, Void, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
     f = eval(finalfunc(init, final, Base.function_name(final)))
-    cf = cfunction(f, Nothing, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
+    cf = cfunction(f, Void, (Ptr{Void}, Cint, Ptr{Ptr{Void}}))
 
     enc = SQLITE_UTF8
     enc = isdeterm ? enc | SQLITE_DETERMINISTIC : enc

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,22 +1,22 @@
 function sqlite3_errmsg()
     return ccall( (:sqlite3_errmsg, sqlite3_lib),
-        Ptr{Uint8}, ()
+        Ptr{UInt8}, ()
         )
 end
 function sqlite3_errmsg(db::Ptr{Void})
     @NULLCHECK db
     return ccall( (:sqlite3_errmsg, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void},),
+        Ptr{UInt8}, (Ptr{Void},),
         db)
 end
 function sqlite3_open(file::AbstractString,handle::Array{Ptr{Void},1})
     return ccall( (:sqlite3_open, sqlite3_lib),
-        Cint, (Ptr{Uint8},Ptr{Void}),
+        Cint, (Ptr{UInt8},Ptr{Void}),
         file,handle)
 end
 function sqlite3_open16(file::UTF16String,handle::Array{Ptr{Void},1})
     return ccall( (:sqlite3_open16, sqlite3_lib),
-        Cint, (Ptr{Uint16},Ptr{Void}),
+        Cint, (Ptr{UInt16},Ptr{Void}),
         file,handle)
 end
 function sqlite3_close(handle::Ptr{Void})
@@ -34,13 +34,13 @@ end
 function sqlite3_prepare_v2(handle::Ptr{Void},query::AbstractString,stmt::Array{Ptr{Void},1},unused::Array{Ptr{Void},1})
     @NULLCHECK handle
     return ccall( (:sqlite3_prepare_v2, sqlite3_lib),
-        Cint, (Ptr{Void},Ptr{Uint8},Cint,Ptr{Void},Ptr{Void}),
+        Cint, (Ptr{Void},Ptr{UInt8},Cint,Ptr{Void},Ptr{Void}),
             handle,query,sizeof(query),stmt,unused)
 end
 function sqlite3_prepare16_v2(handle::Ptr{Void},query::AbstractString,stmt::Array{Ptr{Void},1},unused::Array{Ptr{Void},1})
     @NULLCHECK handle
     return ccall( (:sqlite3_prepare16_v2, sqlite3_lib),
-        Cint, (Ptr{Void},Ptr{Uint16},Cint,Ptr{Void},Ptr{Void}),
+        Cint, (Ptr{Void},Ptr{UInt16},Cint,Ptr{Void},Ptr{Void}),
         handle,query,sizeof(query),stmt,unused)
 end
 function sqlite3_finalize(stmt::Ptr{Void})
@@ -61,14 +61,14 @@ end
 function sqlite3_bind_parameter_name(stmt::Ptr{Void}, col::Int)
     @NULLCHECK stmt
     return ccall( (:sqlite3_bind_parameter_name, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void}, Cint),
+        Ptr{UInt8}, (Ptr{Void}, Cint),
         stmt, col)
 end
 # SQLITE_API int sqlite3_bind_parameter_index(sqlite3_stmt*, const char *zName);
 function sqlite3_bind_parameter_index(stmt::Ptr{Void},value::AbstractString)
     @NULLCHECK stmt
     return ccall( (:sqlite3_bind_parameter_index, sqlite3_lib),
-        Cint, (Ptr{Void},Ptr{Uint8}),
+        Cint, (Ptr{Void},Ptr{UInt8}),
         stmt,utf8(value))
 end
 # SQLITE_API int sqlite3_bind_double(sqlite3_stmt*, int, double);
@@ -103,21 +103,21 @@ end
 function sqlite3_bind_text(stmt::Ptr{Void},col::Int,value::AbstractString)
     @NULLCHECK stmt
     return ccall( (:sqlite3_bind_text, sqlite3_lib),
-        Cint, (Ptr{Void},Cint,Ptr{Uint8},Cint,Ptr{Void}),
+        Cint, (Ptr{Void},Cint,Ptr{UInt8},Cint,Ptr{Void}),
         stmt,col,value,sizeof(value),C_NULL)
 end
 # SQLITE_API int sqlite3_bind_text16(sqlite3_stmt*, int, const void*, int, void(*)(void*));
 function sqlite3_bind_text16(stmt::Ptr{Void},col::Int,value::UTF16String)
     @NULLCHECK stmt
     return ccall( (:sqlite3_bind_text, sqlite3_lib),
-        Cint, (Ptr{Void},Cint,Ptr{Uint16},Cint,Ptr{Void}),
+        Cint, (Ptr{Void},Cint,Ptr{UInt16},Cint,Ptr{Void}),
         stmt,col,value,sizeof(value),C_NULL)
 end
 # SQLITE_API int sqlite3_bind_blob(sqlite3_stmt*, int, const void*, int n, void(*)(void*));
 function sqlite3_bind_blob(stmt::Ptr{Void},col::Int,value)
     @NULLCHECK stmt
     return ccall( (:sqlite3_bind_blob, sqlite3_lib),
-        Cint, (Ptr{Void},Cint,Ptr{Uint8},Cint,Ptr{Void}),
+        Cint, (Ptr{Void},Cint,Ptr{UInt8},Cint,Ptr{Void}),
         stmt,col,value,sizeof(value),SQLITE_STATIC)
 end
 # SQLITE_API int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
@@ -182,7 +182,7 @@ end
 function sqlite3_column_text(stmt::Ptr{Void},col::Int)
     @NULLCHECK stmt
     return ccall( (:sqlite3_column_text, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void},Cint),
+        Ptr{UInt8}, (Ptr{Void},Cint),
         stmt,col)
 end
 function sqlite3_column_text16(stmt::Ptr{Void},col::Int)
@@ -208,13 +208,13 @@ end
 function sqlite3_column_name(stmt::Ptr{Void},n::Int)
     @NULLCHECK stmt
     return ccall( (:sqlite3_column_name, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void},Cint),
+        Ptr{UInt8}, (Ptr{Void},Cint),
         stmt,n)
 end
 function sqlite3_column_name16(stmt::Ptr{Void},n::Int)
     @NULLCHECK stmt
     return ccall( (:sqlite3_column_name16, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void},Cint),
+        Ptr{UInt8}, (Ptr{Void},Cint),
         stmt,n)
 end
 
@@ -253,13 +253,13 @@ end
 # SQLITE_API void sqlite3_result_error(sqlite3_context*, const char*, int)
 function sqlite3_result_error(context::Ptr{Void},msg::AbstractString)
     return ccall( (:sqlite3_result_error, sqlite3_lib),
-        Void, (Ptr{Void},Ptr{Uint8},Cint),
+        Void, (Ptr{Void},Ptr{UInt8},Cint),
         context,value,sizeof(msg)+1)
 end
 # SQLITE_API void sqlite3_result_error16(sqlite3_context*, const void*, int)
 function sqlite3_result_error(context::Ptr{Void},msg::UTF16String)
     return ccall( (:sqlite3_result_error16, sqlite3_lib),
-        Void, (Ptr{Void},Ptr{Uint16},Cint),
+        Void, (Ptr{Void},Ptr{UInt16},Cint),
         context,value,sizeof(msg)+1)
 end
 # SQLITE_API void sqlite3_result_int(sqlite3_context*, int);
@@ -283,19 +283,19 @@ end
 # SQLITE_API void sqlite3_result_text(sqlite3_context*, const char*, int n, void(*)(void*));
 function sqlite3_result_text(context::Ptr{Void},value::AbstractString)
     return ccall( (:sqlite3_result_text, sqlite3_lib),
-        Void, (Ptr{Void},Ptr{Uint8},Cint,Ptr{Void}),
+        Void, (Ptr{Void},Ptr{UInt8},Cint,Ptr{Void}),
         context,value,sizeof(value)+1,SQLITE_TRANSIENT)
 end
 # SQLITE_API void sqlite3_result_text16(sqlite3_context*, const void*, int, void(*)(void*));
 function sqlite3_result_text16(context::Ptr{Void},value::UTF16String)
     return ccall( (:sqlite3_result_text, sqlite3_lib),
-        Void, (Ptr{Void},Ptr{Uint16},Cint,Ptr{Void}),
+        Void, (Ptr{Void},Ptr{UInt16},Cint,Ptr{Void}),
         context,value,sizeof(value)+1,SQLITE_TRANSIENT)
 end
 # SQLITE_API void sqlite3_result_blob(sqlite3_context*, const void*, int n, void(*)(void*));
 function sqlite3_result_blob(context::Ptr{Void},value)
     return ccall( (:sqlite3_result_blob, sqlite3_lib),
-        Void, (Ptr{Void},Ptr{Uint8},Cint,Ptr{Void}),
+        Void, (Ptr{Void},Ptr{UInt8},Cint,Ptr{Void}),
         context,value,sizeof(value),SQLITE_TRANSIENT)
 end
 # SQLITE_API void sqlite3_result_zeroblob(sqlite3_context*, int n);
@@ -313,7 +313,7 @@ function sqlite3_create_function_v2(db::Ptr{Void},name::AbstractString,nargs::In
     return ccall(
         (:sqlite3_create_function_v2, sqlite3_lib),
         Cint,
-        (Ptr{Void}, Ptr{Uint8}, Cint, Cint, Ptr{Void},
+        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Void},
          Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}),
         db, name, nargs, enc, data, func, step, final, destructor)
 end
@@ -371,7 +371,7 @@ end
 # SQLITE_API const unsigned char* sqlite3_value_text(sqlite3_value*)
 function sqlite3_value_text(value::Ptr{Void})
     return ccall( (:sqlite3_value_text, sqlite3_lib),
-        Ptr{Uint8}, (Ptr{Void},),
+        Ptr{UInt8}, (Ptr{Void},),
         value)
 end
 # SQLITE_API const void* sqlite3_value_text16(sqlite3_value*)
@@ -428,7 +428,7 @@ end
 # SQLITE_API int sqlite3_extended_errcode(sqlite3 *db);
 function sqlite3_errstr(ret::Cint)
     return ccall( (:sqlite3_errstr, sqlite3_lib),
-        Ptr{Uint8}, (Cint,),
+        Ptr{UInt8}, (Cint,),
         ret)
 end
 # SQLITE_API const char *sqlite3_errstr(int);
@@ -456,19 +456,19 @@ end
 # Not directly used
 function sqlite3_open_v2(file::AbstractString,handle::Array{Ptr{Void},1},flags::Cint,vfs::AbstractString)
     return ccall( (:sqlite3_open_v2, sqlite3_lib),
-            Cint, (Ptr{Uint8},Ptr{Void},Cint,Ptr{Uint8}),
+            Cint, (Ptr{UInt8},Ptr{Void},Cint,Ptr{UInt8}),
             file,handle,flags,vfs)
 end
 function sqlite3_prepare(handle::Ptr{Void},query::AbstractString,stmt::Array{Ptr{Void},1},unused::Array{Ptr{Void},1})
     @NULLCHECK handle
     return ccall( (:sqlite3_prepare, sqlite3_lib),
-        Cint, (Ptr{Void},Ptr{Uint8},Cint,Ptr{Void},Ptr{Void}),
+        Cint, (Ptr{Void},Ptr{UInt8},Cint,Ptr{Void},Ptr{Void}),
             handle,query,sizeof(query),stmt,unused)
 end
 function sqlite3_prepare16(handle::Ptr{Void},query::AbstractString,stmt::Array{Ptr{Void},1},unused::Array{Ptr{Void},1})
     @NULLCHECK handle
     return ccall( (:sqlite3_prepare16, sqlite3_lib),
-        Cint, (Ptr{Void},Ptr{Uint8},Cint,Ptr{Void},Ptr{Void}),
+        Cint, (Ptr{Void},Ptr{UInt8},Cint,Ptr{Void},Ptr{Void}),
             handle,query,sizeof(query),stmt,unused)
 end
 function sqlite3_close_v2(handle::Ptr{Void})

--- a/src/show.jl
+++ b/src/show.jl
@@ -31,7 +31,7 @@ end
 #' ourstrwidth("abc")
 #' ourstrwidth(10000)
 begin
-    local io = IOBuffer(Array(Uint8, 80), true, true)
+    local io = IOBuffer(Array(UInt8, 80), true, true)
     global ourstrwidth
     function ourstrwidth(x::Any) # -> Int
         truncate(io, 0)
@@ -41,7 +41,7 @@ begin
     ourstrwidth(x::AbstractString) = strwidth(x) + 2 # -> Int
     ourstrwidth(s::Symbol) = @compat Int(ccall(:u8_strwidth,
                                        Csize_t,
-                                       (Ptr{Uint8}, ),
+                                       (Ptr{UInt8}, ),
                                        string(s)))
 end
 
@@ -359,7 +359,7 @@ function showrows(io::IO,
     for chunkindex in 1:nchunks
         leftcol = chunkbounds[chunkindex] + 1
         rightcol = chunkbounds[chunkindex + 1]
-        
+
         # Print column names
         @printf io "| %s" rowlabel
         padding = rowmaxwidth - ourstrwidth(rowlabel)


### PR DESCRIPTION
1. Renames of deprecated symbols
2. `string(regexp)` now returns "SQLite.regexp", so pass "regexp" as a name explicitly into `register`.